### PR TITLE
Refactor friendship redux state

### DIFF
--- a/frontend/src/components/FriendListItem/FriendListItem.jsx
+++ b/frontend/src/components/FriendListItem/FriendListItem.jsx
@@ -16,14 +16,14 @@ const FriendListItem = ({ user, friendship = false, status = '' }) => {
 		dispatch(friendshipActions.acceptFriendship(currentUser.id, user.sender._id));
 	}
 
-	const declineFriendRequest = e => {
-		e.preventDefault();
-		dispatch(friendshipActions.deletePendingFriendship(currentUser.id, user.sender._id));
-	}
-
 	const cancelFriendRequest = e => {
 		e.preventDefault();
-		dispatch(friendshipActions.deletePendingFriendship(currentUser.id, user.receiver._id));
+		dispatch(friendshipActions.cancelSentRequest(currentUser.id, user.receiver._id));
+	}
+
+	const declineFriendRequest = e => {
+		e.preventDefault();
+		dispatch(friendshipActions.declineReceivedRequest(currentUser.id, user.sender._id));
 	}
 
 	const sendFriendRequest = e => {

--- a/frontend/src/components/FriendsList/FriendsList.jsx
+++ b/frontend/src/components/FriendsList/FriendsList.jsx
@@ -8,8 +8,8 @@ export default function FriendsList() {
   const dispatch = useDispatch();
   const currentUser = useSelector(state => state.user);
   const friends = Object.values(useSelector(state => state.friends));
-  const friendRequests = useSelector(state => state.friendships.friendRequests);
-  const pendingRequests = useSelector(state => state.friendships.pendingRequests);
+  const friendRequests = Object.values(useSelector(state => state.friendships.friendRequests));
+  const pendingRequests = Object.values(useSelector(state => state.friendships.pendingRequests));
   const otherUsers = Object.values(useSelector(state => state.friendships.otherUsers));
 
   useEffect(() => {

--- a/frontend/src/components/FriendsList/FriendsList.jsx
+++ b/frontend/src/components/FriendsList/FriendsList.jsx
@@ -10,7 +10,7 @@ export default function FriendsList() {
   const friends = Object.values(useSelector(state => state.friends));
   const friendRequests = useSelector(state => state.friendships.friendRequests);
   const pendingRequests = useSelector(state => state.friendships.pendingRequests);
-  const otherUsers = useSelector(state => state.friendships.otherUsers);
+  const otherUsers = Object.values(useSelector(state => state.friendships.otherUsers));
 
   useEffect(() => {
     dispatch(friendshipActions.fetchFriendRequests(currentUser.id));

--- a/frontend/src/components/FriendsList/FriendsList.jsx
+++ b/frontend/src/components/FriendsList/FriendsList.jsx
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from "react-redux"
+import { shallowEqual, useDispatch, useSelector } from "react-redux"
 import FriendListItem from "../FriendListItem/FriendListItem";
 import { useEffect } from "react";
 import * as friendshipActions from '../../store/friendships';
@@ -8,9 +8,9 @@ export default function FriendsList() {
   const dispatch = useDispatch();
   const currentUser = useSelector(state => state.user);
   const friends = Object.values(useSelector(state => state.friends));
-  const friendRequests = Object.values(useSelector(state => state.friendships.friendRequests));
-  const pendingRequests = Object.values(useSelector(state => state.friendships.pendingRequests));
-  const otherUsers = Object.values(useSelector(state => state.friendships.otherUsers));
+  const friendRequests = Object.values(useSelector(state => state.friendships.friendRequests, shallowEqual));
+  const pendingRequests = Object.values(useSelector(state => state.friendships.pendingRequests, shallowEqual));
+  const otherUsers = Object.values(useSelector(state => state.friendships.otherUsers, shallowEqual));
 
   useEffect(() => {
     dispatch(friendshipActions.fetchFriendRequests(currentUser.id));
@@ -20,19 +20,19 @@ export default function FriendsList() {
 
   return (
     <div className="friends-section">
-      <h3>Friends</h3>
+      <h3>Friends ({friends?.length})</h3>
       {friends?.map(friend => {
         return <FriendListItem key={friend._id} user={friend} friendship={true} />
       })}
-      <h3>Friend Requests</h3>
+      <h3>Friend Requests ({friendRequests?.length})</h3>
       {friendRequests?.map(request => {
         return <FriendListItem key={request.sender._id} user={request} friendship={false} status='request' />
       })}
-      <h3>Pending Requests</h3>
+      <h3>Pending Requests ({pendingRequests?.length})</h3>
       {pendingRequests?.map(request => {
         return <FriendListItem key={request.receiver._id} user={request} friendship={false} status='pending' />
       })}
-      <h3>Search for Friends</h3>
+      <h3>Search for Friends ({otherUsers?.length})</h3>
       {otherUsers?.map(user => {
         return <FriendListItem key={user._id} user={user} friendship={false} status='none' />
       })}

--- a/frontend/src/components/FriendsList/FriendsList.jsx
+++ b/frontend/src/components/FriendsList/FriendsList.jsx
@@ -8,9 +8,9 @@ export default function FriendsList() {
   const dispatch = useDispatch();
   const currentUser = useSelector(state => state.user);
   const friends = Object.values(useSelector(state => state.friends));
-  const friendRequests = Object.values(useSelector(state => state.friendships.friendRequests, shallowEqual));
-  const pendingRequests = Object.values(useSelector(state => state.friendships.pendingRequests, shallowEqual));
-  const otherUsers = Object.values(useSelector(state => state.friendships.otherUsers, shallowEqual));
+  const friendRequests = Object.values(useSelector(state => state.friendships.friendRequests));
+  const pendingRequests = Object.values(useSelector(state => state.friendships.pendingRequests));
+  const otherUsers = Object.values(useSelector(state => state.friendships.otherUsers));
 
   useEffect(() => {
     dispatch(friendshipActions.fetchFriendRequests(currentUser.id));

--- a/frontend/src/components/FriendsList/FriendsList.jsx
+++ b/frontend/src/components/FriendsList/FriendsList.jsx
@@ -20,19 +20,19 @@ export default function FriendsList() {
 
   return (
     <div className="friends-section">
-      <h3>Friends ({friends?.length})</h3>
+      <h3>Friends</h3>
       {friends?.map(friend => {
         return <FriendListItem key={friend._id} user={friend} friendship={true} />
       })}
-      <h3>Friend Requests ({friendRequests?.length})</h3>
+      <h3>Friend Requests</h3>
       {friendRequests?.map(request => {
         return <FriendListItem key={request.sender._id} user={request} friendship={false} status='request' />
       })}
-      <h3>Pending Requests ({pendingRequests?.length})</h3>
+      <h3>Pending Requests</h3>
       {pendingRequests?.map(request => {
         return <FriendListItem key={request.receiver._id} user={request} friendship={false} status='pending' />
       })}
-      <h3>Search for Friends ({otherUsers?.length})</h3>
+      <h3>Search for Friends</h3>
       {otherUsers?.map(user => {
         return <FriendListItem key={user._id} user={user} friendship={false} status='none' />
       })}

--- a/frontend/src/store/friends.js
+++ b/frontend/src/store/friends.js
@@ -14,7 +14,7 @@ const friendsReducer = (state = {}, action) => {
       }
       return newState;
     case ACCEPT_FRIEND_REQUEST:
-      return { ...state, [action.friendship._id]: action.friendship };
+      return { ...state, [action.friendship.sender._id]: action.friendship.sender };
     case REMOVE_FRIENDSHIP:
       const nextState = { ...state };
       delete nextState[action.friendshipId];

--- a/frontend/src/store/friendships.js
+++ b/frontend/src/store/friendships.js
@@ -48,9 +48,9 @@ const removeFriendship = friendshipId => ({
 	friendshipId
 })
 
-const cancelFriendRequest = friendshipId => ({
+const cancelFriendRequest = friendship => ({
 	type: CANCEL_FRIEND_REQUEST,
-	friendshipId
+	friendship
 })
 
 const declineFriendRequest = friendshipId => ({
@@ -175,6 +175,12 @@ const FriendshipsReducer = (state = initialState, action) => {
 			delete newState.friendRequests[action.friendship._id];
 			return newState
 		case CANCEL_FRIEND_REQUEST:
+			// Need ID of the user to get user info from pendingRequests.
+			// Or we can fetch the user info from the backend and attach it to the response
+			// Make the action have friendship info and user info.
+			const userId = newState.pendingRequests[action.friendship._id].receiver._id;
+			const userInfo = newState.pendingRequests[action.friendship_id].receiver;
+			newState.otherUsers[userId] = userInfo;
 			delete newState.pendingRequests[action.friendshipId];
 			return newState;
 		case DECLINE_FRIEND_REQUEST:

--- a/frontend/src/store/friendships.js
+++ b/frontend/src/store/friendships.js
@@ -160,31 +160,36 @@ const initialState = {
 const FriendshipsReducer = (state = initialState, action) => {
 	const newState = { ...state };
 	switch (action.type) {
+		// Loading actions.
 		case RECEIVE_OTHER_USERS:
 			return { ...state, otherUsers: action.otherUsers };
 		case RECEIVE_PENDING_REQUESTS:
 			return { ...state, pendingRequests: action.pendingRequests };
 		case RECEIVE_FRIEND_REQUESTS:
 			return { ...state, friendRequests: action.friendRequests };
+		// Updating actions
 		case SEND_FRIEND_REQUEST:
 			// Add friendship to pending requests and remove from other users.
 			newState.pendingRequests[action.friendship._id] = action.friendship;
-			delete newState.otherUsers[action.friendship.receiver];
+			delete newState.otherUsers[action.friendship.receiver._id];
 			return newState;
 		case ACCEPT_FRIEND_REQUEST:
 			delete newState.friendRequests[action.friendship._id];
 			return newState
+		// Used for cancelling a sent request
 		case CANCEL_FRIEND_REQUEST:
-			// Need ID of the user to get user info from pendingRequests.
-			// Or we can fetch the user info from the backend and attach it to the response
-			// Make the action have friendship info and user info.
-			const userId = newState.pendingRequests[action.friendship._id].receiver._id;
-			const userInfo = newState.pendingRequests[action.friendship_id].receiver;
-			newState.otherUsers[userId] = userInfo;
-			delete newState.pendingRequests[action.friendshipId];
+			// You need userInfo to populate the otherUsers slice of state.
+			const pendingUserId = newState.pendingRequests[action.friendship._id].receiver._id;
+			const pendingUserInfo = newState.pendingRequests[action.friendship._id].receiver;
+			newState.otherUsers[pendingUserId] = pendingUserInfo;
+			delete newState.pendingRequests[action.friendship._id];
 			return newState;
+		// You need userInfo to populate the otherUsers slice of state.
 		case DECLINE_FRIEND_REQUEST:
-			delete newState.friendRequests[action.friendshipId];
+			const userId = newState.friendRequests[action.friendship._id].sender._id;
+			const userInfo = newState.friendRequests[action.friendship._id].sender;
+			newState.otherUsers[userId] = userInfo;
+			delete newState.friendRequests[action.friendship._id];
 			return newState;
 		default:
 			return state;

--- a/frontend/src/store/friendships.js
+++ b/frontend/src/store/friendships.js
@@ -158,7 +158,6 @@ const initialState = {
 }
 
 const FriendshipsReducer = (state = initialState, action) => {
-	// const newState = { ...state };
 	const newState = {
 		otherUsers: { ...state.otherUsers },
 		pendingRequests: { ...state.pendingRequests },

--- a/frontend/src/store/friendships.js
+++ b/frontend/src/store/friendships.js
@@ -4,9 +4,9 @@ const RECEIVE_OTHER_USERS = 'RECEIVE_OTHER_USERS';
 const RECEIVE_FRIEND_REQUESTS = 'RECEIVE_FRIEND_REQUESTS';
 const RECEIVE_PENDING_REQUESTS = 'RECEIVE_PENDING_REQUESTS';
 
-const SEND_FRIEND_REQUEST = 'SEND_FRIEND_REQUEST';
-const CANCEL_FRIEND_REQUEST = 'CANCEL_FRIEND_REQUEST';
-const DECLINE_FRIEND_REQUEST = 'DECLINE_FRIEND_REQUEST';
+export const SEND_FRIEND_REQUEST = 'SEND_FRIEND_REQUEST';
+export const CANCEL_FRIEND_REQUEST = 'CANCEL_FRIEND_REQUEST';
+export const DECLINE_FRIEND_REQUEST = 'DECLINE_FRIEND_REQUEST';
 export const ACCEPT_FRIEND_REQUEST = 'ACCEPT_FRIEND_REQUEST';
 export const REMOVE_FRIENDSHIP = 'REMOVE_FRIENDSHIP';
 
@@ -158,7 +158,12 @@ const initialState = {
 }
 
 const FriendshipsReducer = (state = initialState, action) => {
-	const newState = { ...state };
+	// const newState = { ...state };
+	const newState = {
+		otherUsers: { ...state.otherUsers },
+		pendingRequests: { ...state.pendingRequests },
+		friendRequests: { ...state.friendRequests }
+	}
 	switch (action.type) {
 		// Loading actions.
 		case RECEIVE_OTHER_USERS:

--- a/frontend/src/store/friendships.js
+++ b/frontend/src/store/friendships.js
@@ -51,7 +51,11 @@ export const fetchOtherUsers = userId => async dispatch => {
 
 	if (res.ok) {
 		const otherUsers = await res.json();
-		dispatch(receiveOtherUsers(otherUsers));
+		const otherUsersObj = {};
+		otherUsers.forEach(user => {
+			otherUsersObj[user._id] = user;
+		})
+		dispatch(receiveOtherUsers(otherUsersObj));
 	}
 }
 
@@ -114,7 +118,13 @@ export const deleteAcceptedFriendship = (senderId, otherUserId) => async dispatc
 	}
 }
 
-const FriendshipsReducer = (state = {}, action) => {
+const initialState = {
+	otherUsers: {},
+	// friendRequests: {},
+	// pendingRequests: {}
+}
+
+const FriendshipsReducer = (state = initialState, action) => {
 	switch (action.type) {
 		case RECEIVE_OTHER_USERS:
 			return { ...state, otherUsers: action.otherUsers };
@@ -128,6 +138,7 @@ const FriendshipsReducer = (state = {}, action) => {
 				newState.friendRequests = [];
 			}
 			newState.friendRequests.push(action.friendship);
+			delete newState.otherUsers[action.friendship.receiver];
 			return newState;
 		case ACCEPT_FRIEND_REQUEST:
 			const nextState = { ...state };

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -6,7 +6,6 @@ import wishlist from './wishlist';
 import ownedGames from './ownedGames';
 import friends from './friends';
 import friendships from './friendships';
-import otherUsers from './otherUsers';
 
 const rootReducer = combineReducers({
   user: session,
@@ -15,7 +14,6 @@ const rootReducer = combineReducers({
   friends,
   errors,
   friendships
-  // otherUsers
 });
 
 let enhancer;

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -6,6 +6,7 @@ import wishlist from './wishlist';
 import ownedGames from './ownedGames';
 import friends from './friends';
 import friendships from './friendships';
+import otherUsers from './otherUsers';
 
 const rootReducer = combineReducers({
   user: session,
@@ -14,6 +15,7 @@ const rootReducer = combineReducers({
   friends,
   errors,
   friendships
+  // otherUsers
 });
 
 let enhancer;


### PR DESCRIPTION
FINALLY - rerendering now triggers appropriately when you click on friendship buttons. The issue was not having a deep copy for the nested friendships slice of state. The solution was using:
```
const newState = {
		otherUsers: { ...state.otherUsers },
		pendingRequests: { ...state.pendingRequests },
		friendRequests: { ...state.friendRequests }
}
```
Instead of the basic spread on state
```
const newState = { ...state };
```