### PR TITLE
Fix the issue with removing friends

### DIFF
--- a/backend/routes/api/friendships.js
+++ b/backend/routes/api/friendships.js
@@ -130,17 +130,11 @@ router.delete('/:userId/deletePendingFriendship', async (req, res) => {
       receiver: otherUserId,
       accepted: false
     });
-    if (senderFriendships) {
-      await senderFriendships.populate('receiver', '_id username');
-    }
     const receiverFriendships = await Friendship.findOneAndDelete({
       sender: otherUserId,
       receiver: userId,
       accepted: false
     });
-    if (receiverFriendships) {
-      await receiverFriendships.populate('sender', '_id username');
-    }
     const friendship = senderFriendships || receiverFriendships;
     return res.json(friendship);
   } catch (error) {
@@ -160,13 +154,11 @@ router.delete('/:userId/deleteAcceptedFriendship', async (req, res) => {
       receiver: otherUserId,
       accepted: true
     });
-    await senderFriendships.populate('receiver', '_id username');
     const receiverFriendships = await Friendship.findOneAndDelete({
       sender: otherUserId,
       receiver: userId,
       accepted: true
     });
-    await receiverFriendships.populate('sender', '_id username');
     const friendship = senderFriendships || receiverFriendships;
     const userOne = await User.findById(userId);
     const userTwo = await User.findById(otherUserId);


### PR DESCRIPTION
I had a bug in the backend route with .populate calls on friendship queries that aren't being used. They were causing the backend requests to fail so the friends would show up again because the delete wasn't actually going through. It works now

![Recording 2023-09-15 at 10 26 40](https://github.com/Cuponk/well-played/assets/11892726/9dc2fab5-5bce-4bb3-bb8c-99924b5aea5b)
